### PR TITLE
Handle automatic database size requests

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,2 @@
+[pytest]
+python_files = tests/test_*.py

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,27 @@
+import os
+import sys
+import types
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+os.environ.setdefault("DATABASE_URL_RO", "postgresql+psycopg://vast_ro:vast_ro_pwd@localhost:5433/pagila")
+os.environ.setdefault("DATABASE_URL_RW", "postgresql+psycopg://vast_ro:vast_ro_pwd@localhost:5433/pagila")
+os.environ.setdefault("OPENAI_API_KEY", "test-key")
+
+if "src.vast.service" not in sys.modules:
+    fake_service = types.ModuleType("src.vast.service")
+
+    def _dump_response(**overrides):
+        base = {"ok": False, "artifacts": [], "stderr": "", "stdout": "", "command": "pg_dump"}
+        base.update(overrides)
+        return base
+
+    fake_service.create_dump = lambda *args, **kwargs: _dump_response()
+    fake_service.list_artifacts = lambda: []
+    fake_service.repo_write = lambda *args, **kwargs: {"ok": True}
+    fake_service.apply_sql = lambda *args, **kwargs: {"ok": True, "stderr": "", "stdout": ""}
+    fake_service._assert_privileges = lambda: None
+    sys.modules["src.vast.service"] = fake_service

--- a/tests/test_conversation_db_size.py
+++ b/tests/test_conversation_db_size.py
@@ -1,0 +1,42 @@
+from types import MethodType, SimpleNamespace
+
+from src.vast.conversation import ConversationContext, MessageRole, VastConversation
+
+
+def test_database_size_query_executes(monkeypatch, tmp_path):
+    recorded = {}
+
+    def fake_safe_execute(sql, *args, **kwargs):
+        recorded["sql"] = sql
+        return [SimpleNamespace(_mapping={"size_bytes": 2048, "size_pretty": "2 kB"})]
+
+    monkeypatch.setattr("src.vast.conversation.safe_execute", fake_safe_execute)
+
+    conv = VastConversation.__new__(VastConversation)
+    conv.session_name = "test_size"
+    conv.session_file = tmp_path / "session.json"
+    conv.messages = []
+    conv.context = ConversationContext(database_url="postgresql://test", schema_summary="summary")
+    conv.last_actions = []
+    conv.client = None
+    conv.engine = None
+    conv.system_ops = None
+    conv._save_session = lambda: None
+
+    def fail_llm(self, *args, **kwargs):
+        raise AssertionError("LLM should not be called for database size requests")
+
+    conv._get_llm_response = MethodType(fail_llm, conv)
+
+    response = conv.process("How big is the database right now?")
+
+    assert "2 kB" in response
+    assert "2048" in response
+    assert "pg_database_size" in recorded["sql"]
+    assert conv.messages[0].role is MessageRole.USER
+    assert conv.messages[1].role is MessageRole.EXECUTION
+    assert conv.messages[2].role is MessageRole.ASSISTANT
+
+    metadata = conv.last_actions[0]
+    assert metadata["success"] is True
+    assert metadata["rows"] == [{"size_bytes": 2048, "size_pretty": "2 kB"}]


### PR DESCRIPTION
## Summary
- detect database size questions and run pg_database_size via safe_execute, replying with pretty and raw size values
- capture execution metadata for the automated lookup and persist it in the conversation history
- add a focused pytest plus supporting fixtures to cover the behaviour without requiring external services

## Testing
- pytest tests/test_conversation_db_size.py
- pytest tests/test_guardrails.py *(fails: sqlglot.expressions has no attribute Alter in this environment)*

------
https://chatgpt.com/codex/tasks/task_b_68d08c036ea48329b5f1d1e6470bdbbf